### PR TITLE
uppercase user prompt input

### DIFF
--- a/commands/changes.go
+++ b/commands/changes.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"path"
 	"sync"
+	"strings"
 
 	"github.com/rakyll/drive/types"
 )
@@ -124,5 +125,5 @@ func printChangeList(changes []*types.Change, isNoPrompt bool) bool {
 	var input string
 	fmt.Print("Proceed with the changes? [Y/n]: ")
 	fmt.Scan(&input)
-	return input == "Y"
+	return strings.ToUpper(input) == "Y"
 }


### PR DESCRIPTION
Added uppercase conversion to make this work with lowercase letters too.  I thought this was broke at first till I realized I had to use uppercase letters.  So this change should make it a little more user friendly.

This is my first time editing Go so hopefully it works :-)
