### PR TITLE
hidden path discovery toggleable

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Use `drive help` for further reference.
 	$ drive init [path]
 	$ drive pull [-r -no-prompt path] # pulls from remote
 	$ drive push [-r -no-prompt path] # pushes to the remote
+	$ drive push [-r -hidden path] # pushes also hidden directories and paths to the remote
 	$ drive diff [path] # outputs a diff of local and remote
 	$ drive publish [path] # publishes a file, outputs URL
 

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -76,13 +76,15 @@ func (cmd *pullCmd) Run(args []string) {
 }
 
 type pushCmd struct {
-	isRecursive *bool
+	hidden      *bool
 	isNoPrompt  *bool
+	isRecursive *bool
 }
 
 func (cmd *pushCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.isRecursive = fs.Bool("r", true, "performs the push action recursively")
 	cmd.isNoPrompt = fs.Bool("no-prompt", false, "shows no prompt before applying the push action")
+	cmd.hidden = fs.Bool("hidden", false, "allows syncing of hidden paths")
 	return fs
 }
 
@@ -90,8 +92,9 @@ func (cmd *pushCmd) Run(args []string) {
 	context, path := discoverContext(args)
 	exitWithError(drive.New(context, &drive.Options{
 		Path:        path,
-		IsRecursive: *cmd.isRecursive,
+		Hidden:      *cmd.hidden,
 		IsNoPrompt:  *cmd.isNoPrompt,
+		IsRecursive: *cmd.isRecursive,
 	}).Push())
 }
 

--- a/commands.go
+++ b/commands.go
@@ -31,6 +31,8 @@ type Options struct {
 	IsNoPrompt  bool
 	IsRecursive bool
 	IsForce     bool
+	// Hidden discovers hidden paths if set
+	Hidden      bool
 }
 
 type Commands struct {
@@ -44,6 +46,7 @@ type Commands struct {
 func New(context *config.Context, opts *Options) *Commands {
 	var r *Remote
 	if context != nil {
+		context.Hidden = opts.Hidden
 		r = NewRemoteContext(context)
 	}
 	if opts != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,8 @@ type Context struct {
 	ClientSecret string `json:"client_secret"`
 	RefreshToken string `json:"refresh_token"`
 	AbsPath      string `json:"-"`
+	// Hidden discovers hidden paths if set
+	Hidden       bool
 }
 
 func (c *Context) AbsPathOf(fileOrDirPath string) string {

--- a/push.go
+++ b/push.go
@@ -109,8 +109,7 @@ func list(context *config.Context, path string) (files []*File, err error) {
 		return
 	}
 	for _, file := range f {
-		// ignore hidden files
-		if !strings.HasPrefix(file.Name(), ".") {
+		if  context.Hidden || !strings.HasPrefix(file.Name(), ".") {
 			files = append(files, NewLocalFile(gopath.Join(absPath, file.Name()), file))
 		}
 	}


### PR DESCRIPTION
This addresses issue #4 . Hidden path toggling is done via command line options.
By default follows the original behaviour ie ignoring hidden paths.
