### PR TITLE
Implement a list method

### DIFF
--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -30,6 +30,7 @@ var context *config.Context
 
 const (
 	descInit    = "inits a directory and authenticates user"
+	descList    = "list files on google drive"
 	descPull    = "pulls remote changes from google drive"
 	descPush    = "push local changes to google drive"
 	descDiff    = "compares a local file with remote"
@@ -38,6 +39,7 @@ const (
 
 func main() {
 	command.On("init", descInit, &initCmd{}, []string{})
+	command.On("list", descList, &listCmd{}, []string{})
 	command.On("pull", descPull, &pullCmd{}, []string{})
 	command.On("push", descPush, &pushCmd{}, []string{})
 	command.On("diff", descDiff, &diffCmd{}, []string{})
@@ -54,6 +56,21 @@ func (cmd *initCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 func (cmd *initCmd) Run(args []string) {
 	exitWithError(drive.New(initContext(args), nil).Init())
 }
+
+type listCmd struct {
+}
+
+func (cmd *listCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
+	return fs
+}
+
+func (cmd *listCmd) Run(args []string) {
+	context, path := discoverContext(args)
+	exitWithError(drive.New(context, &drive.Options{
+		Path:        path,
+	}).List())
+}
+
 
 type pullCmd struct {
 	isRecursive *bool

--- a/list.go
+++ b/list.go
@@ -1,0 +1,43 @@
+// Copyright 2013 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drive
+
+import (
+	"fmt"
+)
+
+// List remote files if remote path exists. If path is a
+// directory, it recursively lists
+func (g *Commands) List() (err error) {
+	var r *File
+	if r, err = g.rem.FindByPath(g.opts.Path); err != nil {
+		return
+	}
+
+	if (!r.IsDir) {
+		fmt.Println(r.Name)
+		return
+	}
+
+	var remoteChildren []*File
+	if remoteChildren, err = g.rem.FindByParentId(r.Id); err != nil {
+		return
+	}
+
+	for _, rc := range remoteChildren {
+		fmt.Println(rc.Name)
+	}
+	return
+}


### PR DESCRIPTION
This change implements a barebones list method to let users see what files exist on their
drive (a nice complement to the pull function).

Right now it just dumps a list of files and directories:
If the path is a file then it is listed.
If the path is a directory then the direct children are listed.

Note this partially address issue #9. 

Future work. Add options to list details about files in the cloud. Make it so users can tell files and directories apart. 
