### PR TITLE
relative local path implemented

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -16,7 +16,9 @@ package drive
 
 import (
 	"fmt"
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 )
@@ -31,6 +33,57 @@ func (d *dirList) Name() string {
 		return d.remote.Name
 	}
 	return d.local.Name
+}
+
+// Resolves the local path relative to the root directory
+// then performs either Push or Pull depending on 'isPush'
+func (g *Commands) syncByRelativePath(isPush bool) (err error) {
+	root := g.context.AbsPathOf("")
+	absPath := g.context.AbsPathOf(g.opts.Path)
+	relPath := ""
+
+	if absPath != root {
+		if relPath, err = filepath.Rel(root, absPath); err != nil {
+			return
+		}
+	} else {
+		var cwd string
+		if cwd, err = os.Getwd(); err != nil {
+			return
+		}
+		if cwd == root {
+			relPath = ""
+		} else if relPath, err = filepath.Rel(root, cwd); err != nil {
+			return
+		}
+	}
+     
+	relPath = strings.Join([]string{"", relPath}, "/")
+	var r, l *File
+	if r, err = g.rem.FindByPath(relPath); err != nil {
+		// We cannot pull from a non-existant remote
+		if !isPush {
+			return
+		}
+	}
+	localinfo, _ := os.Stat(absPath)
+	if localinfo != nil {
+		l = NewLocalFile(relPath, localinfo)
+	}
+
+	var cl []*Change
+	fmt.Println("Resolving...")
+	if cl, err = g.resolveChangeListRecv(isPush, relPath, r, l); err != nil {
+		return
+	}
+
+	if ok := printChangeList(cl, g.opts.IsNoPrompt); ok {
+		if isPush {
+			return g.playPushChangeList(cl)
+		}
+		return g.playPullChangeList(cl)
+	}
+	return
 }
 
 func (g *Commands) resolveChangeListRecv(

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"path/filepath"
 
 	"github.com/rakyll/command"
@@ -137,15 +138,21 @@ func discoverContext(args []string) (*config.Context, string) {
 	exitWithError(err)
 	relPath := ""
 	if len(args) > 0 {
-		relPath, err = filepath.Rel(context.AbsPath, args[0])
+		var headAbsArg string
+		if headAbsArg, err = filepath.Abs(args[0]); err == nil {
+			relPath, err = filepath.Rel(context.AbsPath, headAbsArg)
+		}
 	}
+
 	exitWithError(err)
+
+	relPath = strings.Join([]string{"", relPath}, "/")
 	return context, relPath
 }
 
 func getContextPath(args []string) (contextPath string) {
 	if len(args) > 0 {
-		contextPath = args[0]
+		contextPath, _ = filepath.Abs(args[0])
 	}
 	if contextPath == "" {
 		contextPath, _ = os.Getwd()

--- a/pull.go
+++ b/pull.go
@@ -15,7 +15,6 @@
 package drive
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -30,26 +29,7 @@ const (
 // directory, it recursively pulls from the remote if there are remote changes.
 // It doesn't check if there are remote changes if isForce is set.
 func (g *Commands) Pull() (err error) {
-	var r, l *File
-	if r, err = g.rem.FindByPath(g.opts.Path); err != nil {
-		return
-	}
-	absPath := g.context.AbsPathOf(g.opts.Path)
-	localinfo, _ := os.Stat(absPath)
-	if localinfo != nil {
-		l = NewLocalFile(absPath, localinfo)
-	}
-
-	var cl []*Change
-	fmt.Println("Resolving...")
-	if cl, err = g.resolveChangeListRecv(false, g.opts.Path, r, l); err != nil {
-		return
-	}
-
-	if ok := printChangeList(cl, g.opts.IsNoPrompt); ok {
-		return g.playPullChangeList(cl)
-	}
-	return
+	return g.syncByRelativePath(false)
 }
 
 func (g *Commands) playPullChangeList(cl []*Change) (err error) {

--- a/push.go
+++ b/push.go
@@ -15,7 +15,6 @@
 package drive
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	gopath "path"
@@ -24,32 +23,11 @@ import (
 	"github.com/rakyll/drive/config"
 )
 
-// Pushes to remote if local path exists and in a god context. If path is a
+// Pushes to remote if local path exists and in a gd context. If path is a
 // directory, it recursively pushes to the remote if there are local changes.
 // It doesn't check if there are local changes if isForce is set.
 func (g *Commands) Push() (err error) {
-	absPath := g.context.AbsPathOf(g.opts.Path)
-	r, err := g.rem.FindByPath(g.opts.Path)
-	if err != nil && err != ErrPathNotExists {
-		return err
-	}
-
-	var l *File
-	localinfo, _ := os.Stat(absPath)
-	if localinfo != nil {
-		l = NewLocalFile(absPath, localinfo)
-	}
-
-	fmt.Println("Resolving...")
-	var cl []*Change
-	if cl, err = g.resolveChangeListRecv(true, g.opts.Path, r, l); err != nil {
-		return err
-	}
-
-	if ok := printChangeList(cl, g.opts.IsNoPrompt); ok {
-		return g.playPushChangeList(cl)
-	}
-	return
+	return g.syncByRelativePath(true)
 }
 
 func (g *Commands) playPushChangeList(cl []*Change) (err error) {


### PR DESCRIPTION
This addresses #19 however is a subset of issue #39 

Adds the ability for one to go like this:
mkdir ~/drive
cd drive
drive init
...
drive pull Photos
cd Photos
drive push
drive publish Photos
and any other natural operations.

refactoring: pull & push into changes
