### PR TITLE
Use GOOGLE_API_CLIENT_ID and GOOGLE_API_CLIENT_SECRET

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
     go get github.com/rakyll/drive/cmd/drive
 
+You must set `GOOGLE_API_CLIENT_ID` and `GOOGLE_API_CLIENT_SECRET` appropriately in your environment before running `drive`.  For more information, see [the Google API docs](https://developers.google.com/drive/web/quickstart/quickstart-go#step_1_enable_the_drive_api).
+
 Use `drive help` for further reference.
 
 	$ drive init [path]

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 
     go get github.com/rakyll/drive/cmd/drive
 
-You must set `GOOGLE_API_CLIENT_ID` and `GOOGLE_API_CLIENT_SECRET` appropriately in your environment before running `drive`.  For more information, see [the Google API docs](https://developers.google.com/drive/web/quickstart/quickstart-go#step_1_enable_the_drive_api).
-
 Use `drive help` for further reference.
 
 	$ drive init [path]
@@ -18,6 +16,8 @@ Use `drive help` for further reference.
 	$ drive push [-r -hidden path] # pushes also hidden directories and paths to the remote
 	$ drive diff [path] # outputs a diff of local and remote
 	$ drive publish [path] # publishes a file, outputs URL
+
+To use your own Google Drive API credentials instead of the built-in credentials, set `GOOGLE_API_CLIENT_ID` and `GOOGLE_API_CLIENT_SECRET` appropriately in your environment before running `drive init`.  See [the Google API docs](https://developers.google.com/drive/web/quickstart/quickstart-go#step_1_enable_the_drive_api) for more information.
 
 ## Why another Google Drive client?
 Background sync is not just hard, it's stupid. My technical and philosophical rants about why it is not worth to implement:

--- a/init.go
+++ b/init.go
@@ -15,8 +15,8 @@
 package drive
 
 import (
-    "os"
-    "errors"
+	"os"
+	"errors"
 )
 
 const (
@@ -28,16 +28,16 @@ func (g *Commands) Init() (err error) {
 	var refresh string
 
 	g.context.ClientId = os.Getenv(clientIdEnvKey)
-    if len(g.context.ClientId) == 0 {
-        err = errors.New("environment variable " + clientIdEnvKey + " must be set")
-        return
-    }
+	if len(g.context.ClientId) == 0 {
+		err = errors.New("environment variable " + clientIdEnvKey + " must be set")
+		return
+	}
 
 	g.context.ClientSecret = os.Getenv(clientSecretEnvKey)
-    if len(g.context.ClientSecret) == 0 {
-        err = errors.New("environment variable " + clientSecretEnvKey + " must be set")
-        return
-    }
+	if len(g.context.ClientSecret) == 0 {
+		err = errors.New("environment variable " + clientSecretEnvKey + " must be set")
+		return
+	}
 
 	if refresh, err = RetrieveRefreshToken(g.context); err != nil {
 		return

--- a/init.go
+++ b/init.go
@@ -14,29 +14,21 @@
 
 package drive
 
-import (
-	"os"
-	"errors"
-)
+import "os"
 
 const (
-	clientIdEnvKey = "GOOGLE_API_CLIENT_ID"
+	clientIDEnvKey = "GOOGLE_API_CLIENT_ID"
 	clientSecretEnvKey = "GOOGLE_API_CLIENT_SECRET"
 )
 
 func (g *Commands) Init() (err error) {
 	var refresh string
 
-	g.context.ClientId = os.Getenv(clientIdEnvKey)
-	if len(g.context.ClientId) == 0 {
-		err = errors.New("environment variable " + clientIdEnvKey + " must be set")
-		return
-	}
-
+	g.context.ClientId = os.Getenv(clientIDEnvKey)
 	g.context.ClientSecret = os.Getenv(clientSecretEnvKey)
-	if len(g.context.ClientSecret) == 0 {
-		err = errors.New("environment variable " + clientSecretEnvKey + " must be set")
-		return
+	if len(g.context.ClientId) == 0 || len(g.context.ClientSecret) == 0 {
+		g.context.ClientId = "354790962074-7rrlnuanmamgg1i4feed12dpuq871bvd.apps.googleusercontent.com"
+		g.context.ClientSecret = "RHjKdah8RrHFwu6fcc0uEVCw"
 	}
 
 	if refresh, err = RetrieveRefreshToken(g.context); err != nil {

--- a/init.go
+++ b/init.go
@@ -14,11 +14,13 @@
 
 package drive
 
+import "os"
+
 func (g *Commands) Init() (err error) {
 	var refresh string
 	// TODO: read from env variable.
-	g.context.ClientId = "354790962074-7rrlnuanmamgg1i4feed12dpuq871bvd.apps.googleusercontent.com"
-	g.context.ClientSecret = "RHjKdah8RrHFwu6fcc0uEVCw"
+	g.context.ClientId = os.Getenv("GOOGLE_API_CLIENT_ID")
+	g.context.ClientSecret = os.Getenv("GOOGLE_API_CLIENT_SECRET")
 	if refresh, err = RetrieveRefreshToken(g.context); err != nil {
 		return
 	}

--- a/init.go
+++ b/init.go
@@ -14,13 +14,31 @@
 
 package drive
 
-import "os"
+import (
+    "os"
+    "errors"
+)
+
+const (
+	clientIdEnvKey = "GOOGLE_API_CLIENT_ID"
+	clientSecretEnvKey = "GOOGLE_API_CLIENT_SECRET"
+)
 
 func (g *Commands) Init() (err error) {
 	var refresh string
-	// TODO: read from env variable.
-	g.context.ClientId = os.Getenv("GOOGLE_API_CLIENT_ID")
-	g.context.ClientSecret = os.Getenv("GOOGLE_API_CLIENT_SECRET")
+
+	g.context.ClientId = os.Getenv(clientIdEnvKey)
+    if len(g.context.ClientId) == 0 {
+        err = errors.New("environment variable " + clientIdEnvKey + " must be set")
+        return
+    }
+
+	g.context.ClientSecret = os.Getenv(clientSecretEnvKey)
+    if len(g.context.ClientSecret) == 0 {
+        err = errors.New("environment variable " + clientSecretEnvKey + " must be set")
+        return
+    }
+
 	if refresh, err = RetrieveRefreshToken(g.context); err != nil {
 		return
 	}


### PR DESCRIPTION
Hi rakyll,

Thanks for writing the drive tool---it's very nice. :)  I changed Init() to read GOOGLE_API_CLIENT_ID and GOOGLE_API_CLIENT_SECRET, respectively, from the environment.  If either is empty, an error is returned.  This is minimalistic, and won't work for everyone, but if you like it feel free to merge.  (This is also my first foray into go so it may not be very idiomatic!)

Chandler
