### PR TITLE
unpublish implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Use `drive help` for further reference.
 	$ drive push [-r -no-prompt path] # pushes to the remote
 	$ drive push [-r -hidden path] # pushes also hidden directories and paths to the remote
 	$ drive diff [path] # outputs a diff of local and remote
-	$ drive publish [path] # publishes a file, outputs URL
+	$ drive pub [path] # publishes a file, outputs URL
+	$ drive unpub [path] # revokes public access to the file
 
 ## Configuration
 

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -29,11 +29,12 @@ import (
 var context *config.Context
 
 const (
-	descInit    = "inits a directory and authenticates user"
-	descPull    = "pulls remote changes from google drive"
-	descPush    = "push local changes to google drive"
-	descDiff    = "compares a local file with remote"
-	descPublish = "publishes a file and prints its publicly available url"
+	descInit      = "inits a directory and authenticates user"
+	descPull      = "pulls remote changes from google drive"
+	descPush      = "push local changes to google drive"
+	descDiff      = "compares a local file with remote"
+	descPublish   = "publishes a file and prints its publicly available url"
+	descUnpublish = "revokes public access to a file"
 )
 
 func main() {
@@ -42,6 +43,7 @@ func main() {
 	command.On("push", descPush, &pushCmd{}, []string{})
 	command.On("diff", descDiff, &diffCmd{}, []string{})
 	command.On("pub", descPublish, &publishCmd{}, []string{})
+	command.On("unpub", descUnpublish, &unpublishCmd{}, []string{})
 	command.ParseAndRun()
 }
 
@@ -112,6 +114,18 @@ func (cmd *diffCmd) Run(args []string) {
 }
 
 type publishCmd struct{}
+type unpublishCmd struct{}
+
+func (cmd *unpublishCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
+	return fs
+}
+
+func (cmd *unpublishCmd) Run(args []string) {
+	context, path := discoverContext(args)
+	exitWithError(drive.New(context, &drive.Options{
+		Path: path,
+	}).Unpublish())
+}
 
 func (cmd *publishCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	return fs

--- a/publish.go
+++ b/publish.go
@@ -30,3 +30,11 @@ func (c *Commands) Publish() (err error) {
 	fmt.Println("Published on", link)
 	return
 }
+
+func (c *Commands) Unpublish() error {
+	file, err := c.rem.FindByPath(c.opts.Path)
+	if err != nil {
+		return err
+	}
+	return c.rem.Unpublish(file.Id)
+}

--- a/remote.go
+++ b/remote.go
@@ -111,6 +111,10 @@ func (r *Remote) Trash(id string) error {
 	return err
 }
 
+func (r *Remote) Unpublish(id string) error {
+	return r.service.Permissions.Delete(id, "anyone").Do()
+}
+
 func (r *Remote) Publish(id string) (string, error) {
 	perm := &drive.Permission{Type: "anyone", Role: "reader"}
 	_, err := r.service.Permissions.Insert(id, perm).Do()


### PR DESCRIPTION
Implemented the reverse of publishing. Uses syntax:
`drive unpub [path]`
to revoke public access to the file.
