### PR TITLE
new maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,13 @@
+# drive has moved
+This project is under new maintenance because I am now too busy to maintain it.
+Find the latest and updated code at https://github.com/odeke-em/drive
+
 # drive
-
-[![Build Status](https://travis-ci.org/rakyll/drive.png?branch=master)](https://travis-ci.org/rakyll/drive)
-
-`drive` is a tiny program to pull or push [Google Drive](https://drive.google.com) files. You need go1.2 installed in order to build the program.
+drive` is a tiny program to pull or push [Google Drive](https://drive.google.com) files. You need at least go1.2 installed in order to build the program.
 
 ## Installation
 
     go get github.com/rakyll/drive/cmd/drive
-
-Use `drive help` for further reference.
-
-	$ drive init [path]
-	$ drive pull [-r] [-no-prompt [path] # pulls from remote
-	$ drive push [-r] [-no-prompt [path] # pushes to the remote
-	$ drive push [-r] [-hidden path] # pushes also hidden directories and paths to the remote
-	$ drive diff [path] # outputs a diff of local and remote
-	$ drive pub [path] # publishes a file, outputs URL
-	$ drive unpub [path] # revokes public access to the file
-
-## Configuration
-
-If you would like to use your own client ID/client secret pair with `drive`, set the `GOOGLE_API_CLIENT_ID` and `GOOGLE_API_CLIENT_SECRET` variables in your environment
-
-## Why another Google Drive client?
-Background sync is not just hard, it's stupid. My technical and philosophical rants about why it is not worth to implement:
-
-* Too racy. Data has been shared between your remote resource, local disk and sometimes in your sync daemon's in-memory struct. Any party could touch a file any time, hard to lock these actions. You end up working with multiple isolated copies of the same file and trying to determine which is the latest version and should be synced across different contexts.
-
-* It requires great scheduling to perform best with your existing environmental constraints. On the other hand, file attributes has an impact on the sync strategy. Large files are blocking, you wouldn't like to sit on and wait for a VM image to get synced before you start to work on a tiny text file.
-
-* It needs to read your mind to understand your priorities. Which file you need most? It needs to read your mind to foresee your future actions. I'm editing a file, and saving the changes time to time. Why not to wait until I feel confident enough to commit the changes to the remote resource?
-
-`drive` is not a sync deamon, it provides:
-
-* Upstreaming and downstreaming. Unlike a sync command, we provide pull and push actions. User has opportunity to decide what to do with their local copy and when. Do some changes, either push it to remote or revert it to the remote version. Perform these actions with user prompt.
-
-	    $ echo "hello" > hello.txt
-	    $ drive push # pushes hello.txt to Google Drive
-	    $ echo "more text" >> hello.txt
-	    $ drive pull # overwrites the local changes with the remote version
-
-* Allowing to work with a specific file or directory, optionally not recursively. If you recently uploaded a large VM image to Google Drive, yet  only a few text files are required for you to work, simply only push/pull the file you want to work with.
-
-	    $ echo "hello" > hello.txt
-	    $ drive push hello.txt # pushes only the specified file
-	    $ drive pull path/to/a/b # pulls the remote directory recursively
-
-* Better I/O scheduling. One of the major goals is to provide better scheduling to improve upload/download times.
-
-* Possibility to support multiple accounts. Pull from or push to multiple Google Drive remotes. Possibility to support multiple backends. Why not to push to Dropbox or Box as well?
-
-## Known issues
-* Probably, it doesn't work on Windows.
-* Google Drive allows a directory to contain files/directories with the same name. Client doesn't handle these cases yet. We don't recommend you to use `drive` if you have such files/directories to avoid data loss.
-* Racing conditions occur if remote is being modified while we're trying to update the file. Google Drive provides resource versioning with ETags, use Etags to avoid racy cases.
 
 ## License
 Copyright 2013 Google Inc. All Rights Reserved.


### PR DESCRIPTION
This addresses issue https://github.com/rakyll/drive/issues/56
Providing the link to the new maintained version as discussed offline.
The license, rights and everything else remain the same, just a new maintainer.
